### PR TITLE
Feature/marketplace 2.0

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -961,7 +961,7 @@ return [
         'concrete' => 'http://marketplace.concretecms.com',
         'concrete_secure' => 'https://marketplace.concretecms.com',
         'concrete_community' => 'https://community.concretecms.com',
-        'package_repository' => 'http://dl.concretecms.com.test',
+        'package_repository' => 'https://dl.market.stage.concretecms.com',
         'marketplace' => 'http://depot.concretecms.com.test',
         'background_feed' => 'https://backgroundimages.concretecms.com/wallpaper',
         'privacy_policy' => '//www.concretecms.com/about/legal/privacy-policy',

--- a/concrete/controllers/backend/marketplace/connect.php
+++ b/concrete/controllers/backend/marketplace/connect.php
@@ -3,11 +3,24 @@ namespace Concrete\Controller\Backend\Marketplace;
 
 use Concrete\Controller\Backend\UserInterface\MarketplaceItem;
 use Concrete\Core\Application\EditResponse;
+use Concrete\Core\Error\ErrorList\ErrorList;
 use Concrete\Core\Legacy\TaskPermission;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
  * @deprecated This will be removed in version 10
  */
 class Connect extends MarketplaceItem
 {
+    public function view()
+    {
+        $errorList = new ErrorList();
+        $errorList->add('Please migrate to the new marketplace.');
+        return new JsonResponse($errorList, 400);
+    }
+
+    protected function canAccess()
+    {
+        return false;
+    }
 }

--- a/concrete/controllers/backend/user_interface/marketplace_item.php
+++ b/concrete/controllers/backend/user_interface/marketplace_item.php
@@ -1,0 +1,29 @@
+<?php
+namespace Concrete\Controller\Backend\UserInterface;
+
+use Concrete\Controller\Backend\UserInterface;
+use Concrete\Core\Legacy\TaskPermission;
+use Concrete\Core\Marketplace\Marketplace;
+use Concrete\Core\Marketplace\RemoteItem;
+
+/**
+ * @deprecated This will be removed in version 10
+ */
+abstract class MarketplaceItem extends UserInterface
+{
+    protected $marketplace;
+    protected $item;
+
+    public function on_start()
+    {
+        parent::on_start();
+        $this->marketplace = Marketplace::getInstance();
+        $this->item = RemoteItem::getByID($this->request->query->get('mpID'));
+    }
+
+    protected function canAccess()
+    {
+        $tp = new TaskPermission();
+        return $this->marketplace->isConnected() && $tp->canInstallPackages() && is_object($this->item);
+    }
+}

--- a/concrete/controllers/dialog/marketplace/checkout.php
+++ b/concrete/controllers/dialog/marketplace/checkout.php
@@ -8,4 +8,8 @@ use Concrete\Controller\Backend\UserInterface\MarketplaceItem;
  */
 class Checkout extends MarketplaceItem
 {
+    public function view()
+    {
+        throw new \RuntimeException('Please migrate to the new marketplace.');
+    }
 }

--- a/concrete/controllers/dialog/marketplace/download.php
+++ b/concrete/controllers/dialog/marketplace/download.php
@@ -2,12 +2,14 @@
 namespace Concrete\Controller\Dialog\Marketplace;
 
 use Concrete\Controller\Backend\UserInterface\MarketplaceItem;
-use Concrete\Core\Package\Package;
-use Concrete\Core\Support\Facade\Package as PackageService;
 
 /**
  * @deprecated This will be removed in version 10
  */
 class Download extends MarketplaceItem
 {
+    public function view()
+    {
+        throw new \RuntimeException('Please migrate to the new marketplace.');
+    }
 }

--- a/concrete/controllers/marketplace.php
+++ b/concrete/controllers/marketplace.php
@@ -12,10 +12,11 @@ use Exception;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use View;
 
-class Marketplace extends BackendUserInterfaceController
+final class Marketplace extends BackendUserInterfaceController
 {
 
     protected $validationToken = 'connect';
+
     /**
      * {@inheritdoc}
      *

--- a/concrete/controllers/single_page/dashboard/extend/addons.php
+++ b/concrete/controllers/single_page/dashboard/extend/addons.php
@@ -5,7 +5,7 @@ use Concrete\Core\Page\Controller\MarketplaceDashboardPageController;
 
 class Addons extends MarketplaceDashboardPageController
 {
-    public function getRedirectLocation()
+    public function getRedirectLocation(): string
     {
         return '/addons';
     }

--- a/concrete/controllers/single_page/dashboard/extend/connect.php
+++ b/concrete/controllers/single_page/dashboard/extend/connect.php
@@ -1,0 +1,20 @@
+<?php
+namespace Concrete\Controller\SinglePage\Dashboard\Extend;
+
+use Concrete\Core\Page\Controller\DashboardPageController;
+
+/**
+ * @deprecated This will be removed in version 10
+ */
+class Connect extends DashboardPageController
+{
+    public function view()
+    {
+        throw new \RuntimeException('Please migrate to the new marketplace.');
+    }
+    public function do_connect()
+    {
+        throw new \RuntimeException('Please migrate to the new marketplace.');
+    }
+
+}

--- a/concrete/controllers/single_page/dashboard/extend/install.php
+++ b/concrete/controllers/single_page/dashboard/extend/install.php
@@ -42,7 +42,7 @@ class Install extends DashboardPageController implements LoggerAwareInterface
         @set_time_limit(0);
     }
 
-    public function view()
+    public function view(): void
     {
         // Get installed packages
         $packages = $this->app->make(PackageService::class);

--- a/concrete/controllers/single_page/dashboard/extend/install.php
+++ b/concrete/controllers/single_page/dashboard/extend/install.php
@@ -33,8 +33,10 @@ class Install extends DashboardPageController implements LoggerAwareInterface
 
     use LoggerAwareTrait;
 
-    protected PackageRepositoryInterface $repository;
-    protected ?Connection $connection;
+    /** @var PackageRepositoryInterface */
+    protected $repository;
+    /** @var Connection|null */
+    protected $connection;
 
     public function on_start()
     {
@@ -176,7 +178,9 @@ class Install extends DashboardPageController implements LoggerAwareInterface
                         $repository = $this->getPackageRepository();
                         $matchingPackages = array_filter(
                             $repository->getPackages($connection),
-                            fn(RemotePackage $rp) => $rp->handle === $p->getPackageHandle()
+                            function (RemotePackage $rp) use ($p) {
+                                return $rp->handle === $p->getPackageHandle();
+                            }
                         );
 
                         if (count($matchingPackages) > 0) {

--- a/concrete/controllers/single_page/dashboard/extend/themes.php
+++ b/concrete/controllers/single_page/dashboard/extend/themes.php
@@ -5,7 +5,7 @@ use Concrete\Core\Page\Controller\MarketplaceDashboardPageController;
 
 class Themes extends MarketplaceDashboardPageController
 {
-    public function getRedirectLocation()
+    public function getRedirectLocation(): string
     {
         return '/themes';
     }

--- a/concrete/controllers/single_page/dashboard/system/basics/marketplace.php
+++ b/concrete/controllers/single_page/dashboard/system/basics/marketplace.php
@@ -7,10 +7,11 @@ use Concrete\Core\Marketplace\PackageRepositoryInterface;
 use Concrete\Core\Marketplace\PurchaseConnectionCoordinator;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\Permission\Checker;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
-class Marketplace extends DashboardPageController
+final class Marketplace extends DashboardPageController
 {
-    public function view()
+    public function view(): void
     {
         if ($errors = $this->app->make('session')->getFlashBag()->get('errors')) {
             foreach ($errors as $error) {
@@ -44,7 +45,7 @@ class Marketplace extends DashboardPageController
         }
     }
 
-    public function update_connection_settings()
+    public function update_connection_settings(): ?RedirectResponse
     {
         if (!$this->token->validate('update_connection_settings')) {
             $this->error->add($this->token->getErrorMessage());
@@ -59,15 +60,17 @@ class Marketplace extends DashboardPageController
             $dbConfig->save('concrete.marketplace.key.private', $this->request->request->get('privateKey'));
             return $this->buildRedirect($this->action('view'));
         }
+
         $this->view();
+        return null;
     }
 
-    public function do_connect()
+    public function do_connect(): ?RedirectResponse
     {
         $this->view();
         if (!$this->token->validate('do_connect')) {
             $this->error->add($this->token->getErrorMessage());
-            return;
+            return null;
         }
 
         $repository = $this->app->make(PackageRepositoryInterface::class);
@@ -75,13 +78,13 @@ class Marketplace extends DashboardPageController
 
         if ($current && $repository->validate($current)) {
             $this->error->add(t('This site is already connected.'));
-            return;
+            return null;
         }
 
         $checker = new Checker();
         if (!$checker->canInstallPackages()) {
             $this->error->add(t('You do not have access to set community configuration values.'));
-            return;
+            return null;
         }
 
         try {

--- a/concrete/controllers/single_page/dashboard/system/update/update.php
+++ b/concrete/controllers/single_page/dashboard/system/update/update.php
@@ -98,7 +98,7 @@ class Update extends DashboardPageController
         }
 
         if (!$this->token->validate('download_update')) {
-//            $this->error->add($this->token->getErrorMessage());
+            $this->error->add($this->token->getErrorMessage());
         }
         if (!is_dir(DIR_CORE_UPDATES)) {
             $this->error->add(t('The directory %s does not exist.', DIR_CORE_UPDATES));

--- a/concrete/single_pages/dashboard/extend/connect.php
+++ b/concrete/single_pages/dashboard/extend/connect.php
@@ -1,0 +1,2 @@
+<?php
+defined('C5_EXECUTE') or die("Access Denied.");

--- a/concrete/single_pages/dashboard/extend/update.php
+++ b/concrete/single_pages/dashboard/extend/update.php
@@ -3,11 +3,11 @@
 use Michelf\Markdown;
 
 /** @var \Concrete\Core\Entity\Package[] $localUpdates */
-$localUpdates ??= [];
+$localUpdates = $localUpdates ?? [];
 /** @var \Concrete\Core\Entity\Package[] $remoteUpdates */
-$remoteUpdates ??= [];
+$remoteUpdates = $remoteUpdates ?? [];
 /** @var \Concrete\Core\Marketplace\Model\RemotePackage[] $remotePackages */
-$remotePackages ??= [];
+$remotePackages = $remotePackages ?? [];
 
 defined('C5_EXECUTE') or die('Access Denied.');
 $valt = Loader::helper('validation/token');
@@ -36,7 +36,9 @@ if (!$tp->canInstallPackages()) {
         <table class="table update-addons-table">
 			<?php
             foreach ($remoteUpdates as $pkg) {
-                $remotePackage = array_first($remotePackages, fn($remote) => $remote->handle === $pkg->getPackageHandle());
+                $remotePackage = array_first($remotePackages, function ($remote) use ($pkg) {
+                    return $remote->handle === $pkg->getPackageHandle();
+                });
                 ?>
 
 				<tr>

--- a/concrete/src/Console/Command/InstallPackageCommand.php
+++ b/concrete/src/Console/Command/InstallPackageCommand.php
@@ -68,7 +68,9 @@ EOT
                 break;
             case 'auto':
                 $associatedPackages = $connection ? $packageRepository->getPackages($connection) : [];
-                $getLanguages = (bool) array_first($associatedPackages, fn($pkg) => $pkg->handle = $pkgHandle);
+                $getLanguages = (bool) array_first($associatedPackages, function ($pkg) use ($pkgHandle) {
+                    return $pkg->handle = $pkgHandle;
+                });
                 break;
             default:
                 throw new InvalidOptionException('Invalid value for the --languages option. Valid values are "yes", "no", "auto"');

--- a/concrete/src/Marketplace/Connection.php
+++ b/concrete/src/Marketplace/Connection.php
@@ -6,8 +6,10 @@ namespace Concrete\Core\Marketplace;
 
 final class Connection implements ConnectionInterface
 {
-    private string $public;
-    private string $private;
+    /** @var string */
+    private $public;
+    /** @var string */
+    private $private;
 
     public function __construct(
         string $public,

--- a/concrete/src/Marketplace/MarketplaceServiceProvider.php
+++ b/concrete/src/Marketplace/MarketplaceServiceProvider.php
@@ -4,6 +4,8 @@ namespace Concrete\Core\Marketplace;
 
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Foundation\Service\Provider;
+use Concrete\Core\Site\Service;
+use GuzzleHttp\Client;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -15,13 +17,16 @@ class MarketplaceServiceProvider extends Provider
         $this->app->bind(PackageRepositoryInterface::class, PackageRepository::class);
         $this->app->bind(PackageRepository::class, function(): PackageRepository {
             $config = $this->app->make(Repository::class);
-            return $this->app->make(PackageRepository::class, [
-                'serializer' => new Serializer([new ObjectNormalizer()], [new JsonEncoder()]),
-                'config' => $config,
-                'databaseConfig' => $this->app->make('config/database'),
-                'baseUri' => $config->get('concrete.urls.package_repository'),
-                'paths' => $config->get('concrete.urls.paths.package_repository'),
-            ]);
+
+            return new PackageRepository(
+                $this->app->make(Client::class),
+                new Serializer([new ObjectNormalizer()], [new JsonEncoder()]),
+                $config,
+                $this->app->make('config/database'),
+                $this->app->make(Service::class),
+                $config->get('concrete.urls.package_repository'),
+                $config->get('concrete.urls.paths.package_repository')
+            );
         });
     }
 }

--- a/concrete/src/Marketplace/MarketplaceServiceProvider.php
+++ b/concrete/src/Marketplace/MarketplaceServiceProvider.php
@@ -13,15 +13,15 @@ class MarketplaceServiceProvider extends Provider
     public function register()
     {
         $this->app->bind(PackageRepositoryInterface::class, PackageRepository::class);
-
-        $this->app->when(PackageRepository::class)->needs(Serializer::class)->give(function () {
-            return new Serializer([new ObjectNormalizer()], [new JsonEncoder()]);
-        });
-        $this->app->when(PackageRepository::class)->needs('$baseUri')->give(function () {
-            return $this->app->make(Repository::class)->get('concrete.urls.package_repository');
-        });
-        $this->app->when(PackageRepository::class)->needs('$paths')->give(function () {
-            return $this->app->make(Repository::class)->get('concrete.urls.paths.package_repository');
+        $this->app->bind(PackageRepository::class, function(): PackageRepository {
+            $config = $this->app->make(Repository::class);
+            return $this->app->make(PackageRepository::class, [
+                'serializer' => new Serializer([new ObjectNormalizer()], [new JsonEncoder()]),
+                'config' => $config,
+                'databaseConfig' => $this->app->make('config/database'),
+                'baseUri' => $config->get('concrete.urls.package_repository'),
+                'paths' => $config->get('concrete.urls.paths.package_repository'),
+            ]);
         });
     }
 }

--- a/concrete/src/Marketplace/Model/ConnectError.php
+++ b/concrete/src/Marketplace/Model/ConnectError.php
@@ -9,8 +9,10 @@ namespace Concrete\Core\Marketplace\Model;
  */
 final class ConnectError
 {
-    public string $error;
-    public int $code;
+    /** @var string */
+    public $error;
+    /** @var int */
+    public $code;
 
     public function __construct(string $error, int $code)
     {

--- a/concrete/src/Marketplace/Model/ConnectError.php
+++ b/concrete/src/Marketplace/Model/ConnectError.php
@@ -7,7 +7,7 @@ namespace Concrete\Core\Marketplace\Model;
 /**
  * @readonly
  */
-class ConnectError
+final class ConnectError
 {
     public string $error;
     public int $code;

--- a/concrete/src/Marketplace/Model/ConnectResult.php
+++ b/concrete/src/Marketplace/Model/ConnectResult.php
@@ -7,7 +7,7 @@ namespace Concrete\Core\Marketplace\Model;
 /**
  * @readonly
  */
-class ConnectResult
+final class ConnectResult
 {
     public string $private;
     public string $public;

--- a/concrete/src/Marketplace/Model/ConnectResult.php
+++ b/concrete/src/Marketplace/Model/ConnectResult.php
@@ -9,9 +9,12 @@ namespace Concrete\Core\Marketplace\Model;
  */
 final class ConnectResult
 {
-    public string $private;
-    public string $public;
-    public string $siteId;
+    /** @var string */
+    public $private;
+    /** @var string */
+    public $public;
+    /** @var string */
+    public $siteId;
 
     public function __construct(string $private, string $public, string $site_id)
     {

--- a/concrete/src/Marketplace/Model/RemotePackage.php
+++ b/concrete/src/Marketplace/Model/RemotePackage.php
@@ -7,7 +7,7 @@ namespace Concrete\Core\Marketplace\Model;
 /**
  * @readonly
  */
-class RemotePackage
+final class RemotePackage
 {
     public string $handle;
     public string $name;

--- a/concrete/src/Marketplace/Model/RemotePackage.php
+++ b/concrete/src/Marketplace/Model/RemotePackage.php
@@ -9,16 +9,26 @@ namespace Concrete\Core\Marketplace\Model;
  */
 final class RemotePackage
 {
-    public string $handle;
-    public string $name;
-    public string $description;
-    public string $summary;
-    public string $download;
-    public string $icon;
-    public string $id;
-    public string $version;
-    public string $fileDescription;
-    public array $compatibility;
+    /** @var string */
+    public $handle;
+    /** @var string */
+    public $name;
+    /** @var string */
+    public $description;
+    /** @var string */
+    public $summary;
+    /** @var string */
+    public $download;
+    /** @var string */
+    public $icon;
+    /** @var string */
+    public $id;
+    /** @var string */
+    public $version;
+    /** @var string */
+    public $fileDescription;
+    /** @var array */
+    public $compatibility;
 
     public function __construct(
         string $handle,

--- a/concrete/src/Marketplace/Model/ValidateResult.php
+++ b/concrete/src/Marketplace/Model/ValidateResult.php
@@ -7,7 +7,7 @@ namespace Concrete\Core\Marketplace\Model;
 /**
  * @readonly
  */
-class ValidateResult
+final class ValidateResult
 {
 
     const VALIDATE_RESULT_SUCCESS = 0;

--- a/concrete/src/Marketplace/Model/ValidateResult.php
+++ b/concrete/src/Marketplace/Model/ValidateResult.php
@@ -14,10 +14,14 @@ final class ValidateResult
     const VALIDATE_RESULT_ERROR = 460;
     CONST VALIDATE_RESULT_ERROR_URL_MISMATCH = 461;
 
-    public bool $valid;
-    public string $site;
-    public string $error;
-    public int $code;
+    /** @var bool */
+    public $valid;
+    /** @var string */
+    public $site;
+    /** @var string */
+    public $error;
+    /** @var int */
+    public $code;
 
     public function __construct(bool $valid, string $site, string $error = '', $code = 0)
     {

--- a/concrete/src/Marketplace/PackageRepositoryInterface.php
+++ b/concrete/src/Marketplace/PackageRepositoryInterface.php
@@ -57,8 +57,9 @@ interface PackageRepositoryInterface
 
     /**
      * Determine if a given connection is valid for the current site
+     * @return bool|ValidateResult
      */
-    public function validate(ConnectionInterface $connection, bool $returnFullObject = false): bool|ValidateResult;
+    public function validate(ConnectionInterface $connection, bool $returnFullObject = false);
 
     /**
      * Sends one or more updated fields to the marketplace backend for optional stage in the remote site object.

--- a/concrete/src/Marketplace/PurchaseConnectionCoordinator.php
+++ b/concrete/src/Marketplace/PurchaseConnectionCoordinator.php
@@ -4,7 +4,7 @@ namespace Concrete\Core\Marketplace;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Foundation\ConcreteObject;
 
-class PurchaseConnectionCoordinator
+final class PurchaseConnectionCoordinator
 {
 
     /**

--- a/concrete/src/Marketplace/Update/Command/UpdateRemoteDataCommand.php
+++ b/concrete/src/Marketplace/Update/Command/UpdateRemoteDataCommand.php
@@ -7,7 +7,7 @@ namespace Concrete\Core\Marketplace\Update\Command;
 use Concrete\Core\Foundation\Command\Command;
 use Concrete\Core\Marketplace\Update\UpdatedFieldInterface;
 
-class UpdateRemoteDataCommand extends Command
+final class UpdateRemoteDataCommand extends Command
 {
 
     /**

--- a/concrete/src/Marketplace/Update/Inspector.php
+++ b/concrete/src/Marketplace/Update/Inspector.php
@@ -7,7 +7,7 @@ namespace Concrete\Core\Marketplace\Update;
 use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Package\PackageService;
 
-class Inspector
+final class Inspector
 {
 
     /**
@@ -61,7 +61,7 @@ class Inspector
         }
         return new UpdatedField(
             UpdatedFieldInterface::FIELD_PACKAGES,
-            json_encode($packageHandles)
+            json_encode($packageHandles, JSON_THROW_ON_ERROR)
         );
     }
 

--- a/concrete/src/Marketplace/Update/UpdatedField.php
+++ b/concrete/src/Marketplace/Update/UpdatedField.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Concrete\Core\Marketplace\Update;
 
-class UpdatedField implements UpdatedFieldInterface
+final class UpdatedField implements UpdatedFieldInterface
 {
-
-    protected $name = '';
-
+    /** @var string */
+    protected $name;
+    /** @var mixed */
     protected $data;
 
     public function __construct(string $name, $data)
@@ -17,9 +17,6 @@ class UpdatedField implements UpdatedFieldInterface
         $this->data = $data;
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
@@ -32,7 +29,4 @@ class UpdatedField implements UpdatedFieldInterface
     {
         return $this->data;
     }
-
-
-
 }

--- a/concrete/src/Page/Controller/MarketplaceDashboardPageController.php
+++ b/concrete/src/Page/Controller/MarketplaceDashboardPageController.php
@@ -1,8 +1,10 @@
 <?php
 namespace Concrete\Core\Page\Controller;
 
+use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Marketplace\PackageRepositoryInterface;
 use Concrete\Core\Marketplace\PurchaseConnectionCoordinator;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Abstract controller for extending Concrete CMS through the Dashboard.
@@ -11,9 +13,9 @@ use Concrete\Core\Marketplace\PurchaseConnectionCoordinator;
 
 abstract class MarketplaceDashboardPageController extends DashboardPageController
 {
-    abstract public function getRedirectLocation();
+    abstract public function getRedirectLocation(): string;
 
-    public function view()
+    public function view(): RedirectResponse
     {
         $repository = $this->app->make(PackageRepositoryInterface::class);
         $coordinator = $this->app->make(PurchaseConnectionCoordinator::class);
@@ -26,8 +28,31 @@ abstract class MarketplaceDashboardPageController extends DashboardPageControlle
                 (string) \URL::to('/dashboard/extend'),
             );
             return $this->buildRedirect($url);
-        } else {
-            return $this->buildRedirect('/dashboard/system/basics/marketplace');
         }
+        return $this->buildRedirect('/dashboard/system/basics/marketplace');
+    }
+
+    /**
+     * @deprecated This will be removed in version 10
+     */
+    public function view_detail(): void
+    {
+        throw new \RuntimeException('Please migrate to the new marketplace.');
+    }
+
+    /**
+     * @deprecated This will be removed in version 10
+     */
+    public function getMarketplaceType()
+    {
+        throw new \RuntimeException('Please migrate to the new marketplace.');
+    }
+
+    /**
+     * @deprecated This will be removed in version 10
+     */
+    public function getMarketplaceDefaultHeading()
+    {
+        throw new \RuntimeException('Please migrate to the new marketplace.');
     }
 }

--- a/concrete/src/SiteInformation/SiteInformationSaver.php
+++ b/concrete/src/SiteInformation/SiteInformationSaver.php
@@ -6,7 +6,7 @@ use Concrete\Core\Marketplace\Update\Command\UpdateRemoteDataCommand;
 use Concrete\Core\Marketplace\Update\UpdatedField;
 use Symfony\Component\HttpFoundation\Request;
 
-class SiteInformationSaver extends DatabaseConfigSaver
+final class SiteInformationSaver extends DatabaseConfigSaver
 {
 
     /**
@@ -20,7 +20,7 @@ class SiteInformationSaver extends DatabaseConfigSaver
         $this->app = $app;
     }
 
-    public function saveFromRequest(Request $request)
+    public function saveFromRequest(Request $request): void
     {
         parent::saveFromRequest($request);
         $fields = [];
@@ -30,6 +30,4 @@ class SiteInformationSaver extends DatabaseConfigSaver
         $command = new UpdateRemoteDataCommand($fields);
         $this->app->executeCommand($command);
     }
-
-
 }


### PR DESCRIPTION
This PR does the following:

1. Adds back backwards compatibility
    1. Restores deleted classes and marks them as `@deprecated`, these can't technically be deleted until a major version. 
    2. Restores deleted methods and marks them as `@deprecated` and modified to throw a runtime exception. Still not great but this makes the fix for the errors that an extender might see more obvious.
2. Improves forward compatibility
    1. I marked all classes that I don't really expect to see extended as `final`. That way we can change them more easily without worrying about extenders that probably don't exist
    2.  Adds return / parameter types where possible
3. Restores compatibility with PHP 7.3. Mostly class property types and union types.
4. Fixes tests by removing unnecessary dependencies from `PackageRepository` and adding test support for new dependencies that are used
5. Updates the config url to the stage marketplace